### PR TITLE
Use the same logic as argparse when storing subcommand argument names

### DIFF
--- a/test_climax.py
+++ b/test_climax.py
@@ -66,12 +66,32 @@ class TestClips(unittest.TestCase):
         @climax.command()
         @climax.option('--repeat', type=int)
         @climax.argument('name')
-        def cmd(repeat, name):
+        @climax.argument('--long-name')
+        @climax.argument('--other-name', dest='third_name')
+        def cmd(repeat, name, long_name, third_name):
             for i in range(repeat):
-                print(name)
+                print(name, long_name, third_name)
 
-        cmd(['--repeat', '3', 'foo'])
-        self.assertEqual(self.stdout.getvalue(), 'foo\nfoo\nfoo\n')
+        cmd(['--repeat', '3', 'foo', '--long-name', 'foobaz', '--other-name', 'baz'])
+        self.assertEqual(self.stdout.getvalue(), 'foo foobaz baz\nfoo foobaz baz\nfoo foobaz baz\n')
+        self.assertEqual(self.stderr.getvalue(), '')
+
+    def test_subcommand_with_arguments(self):
+        @climax.group()
+        def grp():
+            pass
+
+        @grp.command()
+        @climax.option('--repeat', type=int)
+        @climax.argument('name')
+        @climax.argument('--long-name')
+        @climax.argument('--other-name', dest='third_name')
+        def cmd(repeat, name, long_name, third_name):
+            for i in range(repeat):
+                print(name, long_name, third_name)
+
+        grp(['cmd', '--repeat', '3', 'foo', '--long-name', 'foobaz', '--other-name', 'baz'])
+        self.assertEqual(self.stdout.getvalue(), 'foo foobaz baz\nfoo foobaz baz\nfoo foobaz baz\n')
         self.assertEqual(self.stderr.getvalue(), '')
 
     def test_group(self):


### PR DESCRIPTION
Argparse processes argument names to make them valid variable names (e.g. `--long-name` becomes `long_name`) or uses the `dest` keyword argument to determine the variable name (e.g. `argument('--long-name', dest='other_name')`.

when decorating with `climax.argument`, the name of the argument is added to a list of `argnames`, but the transformation applied is different from the argparse one (stripping the `-` prefix, but not converting dashes and not checking `dest`).

This doesn't cause any issues with first level commands, as everything is simply coming from argparse. However, for subcommands, names from the argparse namespace are compared to the stored `argnames` when filtering, and names don't match for arguments with dashes or using the `dest` keyword, leading to the decorated function being called with missing arguments.